### PR TITLE
Add support for war packaging, and missing documentation for options.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 tmp
+.idea

--- a/README.md
+++ b/README.md
@@ -55,21 +55,60 @@ Default: name found in package.json
 
 The maven artifact id to use when deploying and artifact
 
+#### options.packaging
+Type: `String`
+Default: `zip`
+
+The artifact packaging. Supported values are `jar`, `war`, `gzip`, `deflate`, `deflateRaw`, `tar`, `tgz` (tar gzip), and `zip`.
+
+If `options.type` is defined, that parameter is used instead.
+
+#### options.type *(deprecated)*
+Type: `String`
+Optional
+
+This parameter overrides the `options.packaging` parameter.
+
+#### options.classifier
+Type: `String`
+Optional
+
+The artifact classifier.
+
 #### options.version
 Type: `String`
 Default: version found in package.json
 
 The version to use when deploying to the maven repository
 
+#### options.snapshot
+Type: `Boolean`
+Default: `false`
+
+If true, `-SNAPSHOT` is appended to the version.
+
+#### options.file
+Type: `String`
+Default: *artifactId-version.packaging*
+Example: fizzwidget-1.0.0.war
+
+The file
+
+#### options.goal
+Type: `String`
+Default: `deploy`
+
+The action used to deploy the artifact. Supported values are `deploy` or `install`.
+
 #### options.url
 Type: `String`
-Required
+Required when `options.goal` is `deploy` (the default). Ignored otherwise.
 
 The url for the maven repository to deploy to.
 
 #### options.repositoryId
 Type: `String`
-Optional
+Optional. Ignored if `options.goal` is not `deploy`.
 
 The repository id of the repository to deploy to. Used for looking up authentication in settings.xml.
 

--- a/tasks/maven_deploy.js
+++ b/tasks/maven_deploy.js
@@ -28,7 +28,6 @@ module.exports = function(grunt) {
     requireOptionProps(options, ['groupId']);
 
     options.goal = options.goal || this.target;
-    options.packaging = options.type || options.packaging;
 
     if (options.goal === 'deploy') {
       requireOptionProps(options, ['url']);
@@ -46,6 +45,7 @@ module.exports = function(grunt) {
       version: pkg.version,
       packaging: 'zip'
     });
+    options.packaging = options.type || options.packaging;
 
     if (options.snapshot) {
       options.version = options.version + "-SNAPSHOT";
@@ -66,6 +66,7 @@ module.exports = function(grunt) {
       version: pkg.version,
       packaging: 'zip'
     });
+    options.packaging = options.type || options.packaging;
 
     if (options.snapshot) {
       options.version = options.version + "-SNAPSHOT";

--- a/tasks/maven_deploy.js
+++ b/tasks/maven_deploy.js
@@ -28,6 +28,7 @@ module.exports = function(grunt) {
     requireOptionProps(options, ['groupId']);
 
     options.goal = options.goal || this.target;
+    options.packaging = options.type || options.packaging;
 
     if (options.goal === 'deploy') {
       requireOptionProps(options, ['url']);
@@ -86,8 +87,6 @@ module.exports = function(grunt) {
   grunt.registerTask('maven_deploy:install-file', function() {
     var options = grunt.config('maven.install-file.options');
 
-    options.packaging = options.type || options.packaging;
-
     var args = [ 'install:install-file' ];
     args.push('-Dfile='         + options.file);
     args.push('-DgroupId='      + options.groupId);
@@ -120,8 +119,6 @@ module.exports = function(grunt) {
 
   grunt.registerTask('maven_deploy:deploy-file', function() {
     var options = grunt.config('maven.deploy-file.options');
-
-    options.packaging = options.type || options.packaging;
 
     var args = [ 'deploy:deploy-file' ];
     args.push('-Dfile='         + options.file);
@@ -160,7 +157,7 @@ module.exports = function(grunt) {
 
   function guaranteeFileName(options) {
     if (!options.file) {
-      options.file = options.artifactId + '-' + options.version + '.' + (options.type || options.packaging);
+      options.file = options.artifactId + '-' + options.version + '.' + options.packaging;
     }
   }
 

--- a/tasks/maven_deploy.js
+++ b/tasks/maven_deploy.js
@@ -86,10 +86,7 @@ module.exports = function(grunt) {
   grunt.registerTask('maven_deploy:install-file', function() {
     var options = grunt.config('maven.install-file.options');
 
-    if (options.type === 'jar' || options.type === 'war') {
-      options.packaging = options.type;
-      options.file = renameForArtifactType(options.file, options.type);
-    }
+    options.packaging = options.type || options.packaging;
 
     var args = [ 'install:install-file' ];
     args.push('-Dfile='         + options.file);
@@ -124,10 +121,7 @@ module.exports = function(grunt) {
   grunt.registerTask('maven_deploy:deploy-file', function() {
     var options = grunt.config('maven.deploy-file.options');
 
-    if (options.type === 'jar' || options.type === 'war') {
-      options.packaging = options.type;
-      options.file = renameForArtifactType(options.file, options.type);
-    }
+    options.packaging = options.type || options.packaging;
 
     var args = [ 'deploy:deploy-file' ];
     args.push('-Dfile='         + options.file);
@@ -176,8 +170,16 @@ module.exports = function(grunt) {
     }
   }
 
+  var PACKAGING_MODES = {
+    'jar': 'zip',
+    'war': 'zip'
+  };
+
   function configureMaven(options, task) {
-    grunt.config.set('maven.package.options', { archive: options.file, mode: options.packaging });
+    grunt.config.set('maven.package.options', {
+      archive: options.file,
+      mode: PACKAGING_MODES[options.packaging] || options.packaging
+    });
     grunt.config.set('maven.package.files', task.files);
     grunt.config.set('maven.deploy-file.options', options);
     grunt.config.set('maven.install-file.options', options);
@@ -199,16 +201,6 @@ module.exports = function(grunt) {
       grunt.verbose.or.write(msg);
       grunt.log.error().error('Unable to process task.');
       throw grunt.util.error('Required options ' + failProps.join(', ') + ' missing.');
-    }
-  }
-
-  function renameForArtifactType(filename, type) {
-    var typeFilename = filename.replace('zip', type);
-    try {
-      fs.renameSync(filename, typeFilename);
-      return typeFilename;
-    } catch (e) {
-      throw e;
     }
   }
 

--- a/tasks/maven_deploy.js
+++ b/tasks/maven_deploy.js
@@ -86,9 +86,9 @@ module.exports = function(grunt) {
   grunt.registerTask('maven_deploy:install-file', function() {
     var options = grunt.config('maven.install-file.options');
 
-    options.packaging = (options.type === 'jar') ? 'jar' : options.packaging;
-    if (options.packaging === 'jar'){
-        options.file = renameForJarTypeArtifacts(options.file);
+    if (options.type === 'jar' || options.type === 'war') {
+      options.packaging = options.type;
+      options.file = renameForArtifactType(options.file, options.type);
     }
 
     var args = [ 'install:install-file' ];
@@ -124,9 +124,9 @@ module.exports = function(grunt) {
   grunt.registerTask('maven_deploy:deploy-file', function() {
     var options = grunt.config('maven.deploy-file.options');
 
-    options.packaging = (options.type === 'jar') ? 'jar' : options.packaging;
-    if (options.packaging === 'jar'){
-        options.file = renameForJarTypeArtifacts(options.file);
+    if (options.type === 'jar' || options.type === 'war') {
+      options.packaging = options.type;
+      options.file = renameForArtifactType(options.file, options.type);
     }
 
     var args = [ 'deploy:deploy-file' ];
@@ -202,11 +202,11 @@ module.exports = function(grunt) {
     }
   }
 
-  function renameForJarTypeArtifacts(filename) {
-    var warFileName = filename.replace('zip', 'jar');
+  function renameForArtifactType(filename, type) {
+    var typeFilename = filename.replace('zip', type);
     try {
-      fs.renameSync(filename, warFileName);
-      return warFileName;
+      fs.renameSync(filename, typeFilename);
+      return typeFilename;
     } catch (e) {
       throw e;
     }

--- a/tasks/maven_deploy.js
+++ b/tasks/maven_deploy.js
@@ -160,7 +160,7 @@ module.exports = function(grunt) {
 
   function guaranteeFileName(options) {
     if (!options.file) {
-      options.file = options.artifactId + '-' + options.version + '.' + options.packaging;
+      options.file = options.artifactId + '-' + options.version + '.' + (options.type || options.packaging);
     }
   }
 


### PR DESCRIPTION
This pull request:
- adds missing documentation for most if not all undocumented options
- resolves the mismatch between options.type and options.packaging. options.type is effectively an override value for options.packaging.
- adds support for war packaging

From my reading of the code, it appears that the options.type parameter was introduced as a workaround for the options.packaging parameter being used to determine the compression mode used by grunt-contrib-compress.

My changes disconnect the packaging parameter from the compression mode so we can set packaging more freely. During the maven_deploy:package task, the code now uses the packaging to look up the compression mode by packaging, instead of using the packaging as is.

The initial table uses 'zip' mode for both 'jar' and 'war' packaging.

I also changed the semantics of the 'options.type' parameter so it is simply an override of the 'options.packaging' parameter. If both are present, 'options.type' wins. As they are now redundant, I marked the 'type' parameter as deprecated in the README.

Using the packaging parameter directly also allowed for the removal of the file renaming function, as the correct file extension is now used from the start.
