### PR TITLE
[EDIT] remediate vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,17 +34,17 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.6.0",
-    "grunt": "~0.4.2"
+    "grunt-contrib-jshint": "^3.2.0",
+    "grunt": "^1.6.1"
   },
   "peerDependencies": {
-    "grunt": "~0.4.2"
+    "grunt": "^1.6.1"
   },
   "keywords": [
     "gruntplugin"
   ],
   "dependencies": {
-    "grunt": "~0.4.2",
-    "grunt-contrib-compress": "~0.5.3"
+    "grunt": "^1.6.1",
+    "grunt-contrib-compress": "^2.0.0"
   }
 }


### PR DESCRIPTION
This PR is meant to address a critical security issue.

The lodash version (0.9.2) that grunt@0.4.2 is using, has been identified to have a security vulnerability scoring a high 9.8 CVSS score.